### PR TITLE
Do not include field from excluded shelf in the spec

### DIFF
--- a/src/app/spec/spec.service.js
+++ b/src/app/spec/spec.service.js
@@ -25,8 +25,9 @@ angular.module('polestar')
     };
 
     Spec._removeEmptyFieldDefs = function(spec) {
-      spec.encoding = _.omit(spec.encoding, function(fieldDef) {
-        return !fieldDef || (fieldDef.name === undefined && fieldDef.value === undefined);
+      spec.encoding = _.omit(spec.encoding, function(fieldDef, encType) {
+        return !fieldDef || (fieldDef.name === undefined && fieldDef.value === undefined) ||
+          (! vl.schema.schema.properties.encoding.properties[encType].supportedMarktypes[spec.marktype]);
       });
     };
 

--- a/src/app/spec/spec.service.js
+++ b/src/app/spec/spec.service.js
@@ -72,18 +72,14 @@ angular.module('polestar')
 
     // takes a full spec, validates it and then rebuilds everything
     Spec.update = function(spec) {
-      if (!spec) {
-        spec = Spec.spec;
-      }
+      spec = _.cloneDeep(spec || Spec.spec);
 
-      var cleanSpec = _.cloneDeep(spec);
-
-      Spec._removeEmptyFieldDefs(cleanSpec);
-      deleteNulls(cleanSpec);
+      Spec._removeEmptyFieldDefs(spec);
+      deleteNulls(spec);
 
       // we may have removed enc
-      if (!('encoding' in cleanSpec)) {
-        cleanSpec.encoding = {};
+      if (!('encoding' in spec)) {
+        spec.encoding = {};
       }
       var validator = new ZSchema();
 
@@ -91,7 +87,7 @@ angular.module('polestar')
 
       var schema = vl.schema.schema;
       // now validate the spec
-      var valid = validator.validate(cleanSpec, schema);
+      var valid = validator.validate(spec, schema);
 
       if (!valid) {
         //FIXME: move this dependency to directive/controller layer
@@ -99,12 +95,12 @@ angular.module('polestar')
           msg: validator.getLastErrors()
         });
       } else {
-        vl.extend(cleanSpec.config, Config.large());
-        var encoding = vl.Encoding.fromSpec(cleanSpec),
+        vl.extend(spec.config, Config.large());
+        var encoding = vl.Encoding.fromSpec(spec),
           chart = Spec.chart;
 
         chart.fieldSet =  Spec.spec.encoding;
-        chart.vlSpec = Spec.spec;
+        chart.vlSpec = spec;
         chart.cleanSpec = encoding.toSpec(false);
         chart.shorthand = encoding.toShorthand();
         console.log('chart', chart.vgSpec, chart.vlSpec);

--- a/src/app/spec/spec.service.js
+++ b/src/app/spec/spec.service.js
@@ -27,7 +27,7 @@ angular.module('polestar')
     Spec._removeEmptyFieldDefs = function(spec) {
       spec.encoding = _.omit(spec.encoding, function(fieldDef, encType) {
         return !fieldDef || (fieldDef.name === undefined && fieldDef.value === undefined) ||
-          (! vl.schema.schema.properties.encoding.properties[encType].supportedMarktypes[spec.marktype]);
+          (spec.marktype && ! vl.schema.schema.properties.encoding.properties[encType].supportedMarktypes[spec.marktype]);
       });
     };
 

--- a/src/components/fielddefeditor/fielddefeditor.html
+++ b/src/components/fielddefeditor/fielddefeditor.html
@@ -17,7 +17,7 @@
         field="enc[encType]"
         show-type="true"
         show-caret="true"
-        disable-count-or-o-caret="true"
+        disable-count-caret="true"
         popup-content="fieldInfoPopupContent"
         show-remove="true"
         remove-action="removeField()"


### PR DESCRIPTION
- Fixes #205 Do not include field from excluded shelf in the spec
- assign the correct spec to `chart.vlSpec` and refactor variable name to avoid confusion with `chart.cleanSpec`
- follow up changes from d80d37cfa26e60389d45d5e1247b858a0b78fa0e / https://github.com/uwdata/vega-lite-ui/pull/31